### PR TITLE
Add content-type header of application/json to all json routes

### DIFF
--- a/src/main/java/net/fabricmc/meta/web/WebServer.java
+++ b/src/main/java/net/fabricmc/meta/web/WebServer.java
@@ -59,7 +59,7 @@ public class WebServer {
 			ctx.status(400);
 		}
 		String response = GSON.toJson(object);
-		ctx.result(response);
+		ctx.contentType("application/json").result(response);
 	}
 
 }


### PR DESCRIPTION
Simple PR to add correct content-type header to json returning routes.

Tested locally and JSON routes now return the header `Content-Type: application/json` instead of `Content-Type: text/html`.