### PR TITLE
Enable CORS for all origins

### DIFF
--- a/src/main/java/net/fabricmc/meta/web/WebServer.java
+++ b/src/main/java/net/fabricmc/meta/web/WebServer.java
@@ -33,6 +33,7 @@ public class WebServer {
 		javalin = Javalin.create()
 			.enableRouteOverview("/")
 			.disableStartupBanner()
+			.enableCorsForAllOrigins()
 			.start(5555);
 
 		EndpointsV1.setup();


### PR DESCRIPTION
See https://github.com/modmuss50/YarnDiff/issues/1 for an issue caused by the lack of CORS support. This adds support for the OPTIONS preflight request that fails.