### PR TITLE
Add maven jar URL to intermediary objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,13 @@ Lists all of the intermediary versions, stable is based of the minecraft version
 ```json
 [
   {
+    "url": "https://maven.fabricmc.net/net/fabricmc/intermediary/1.14.3-pre3/intermediary-1.14.3-pre3.jar",
     "maven": "net.fabricmc:intermediary:1.14.3-pre3",
     "version": "1.14.3-pre3",
     "stable": false
   },
   {
+    "url": "https://maven.fabricmc.net/net/fabricmc/intermediary/1.14.3-pre2/intermediary-1.14.3-pre2.jar",
     "maven": "net.fabricmc:intermediary:1.14.3-pre2",
     "version": "1.14.3-pre2",
     "stable": false
@@ -96,6 +98,7 @@ Lists all of the intermediary for the provided game version, there will only eve
 ```json
 [
   {
+    "url": "https://maven.fabricmc.net/net/fabricmc/intermediary/1.14/intermediary-1.14.jar",
     "maven": "net.fabricmc:intermediary:1.14",
     "version": "1.14",
     "stable": true
@@ -193,6 +196,7 @@ This returns a list of all the compatible loader versions for a given version of
       "stable": true
     },
     "intermediary": {
+      "url": "https://maven.fabricmc.net/net/fabricmc/intermediary/1.14/intermediary-1.14.jar",
       "maven": "net.fabricmc:intermediary:1.14",
       "version": "1.14",
       "stable": true
@@ -207,6 +211,7 @@ This returns a list of all the compatible loader versions for a given version of
       "stable": false
     },
     "intermediary": {
+      "url": "https://maven.fabricmc.net/net/fabricmc/intermediary/1.14/intermediary-1.14.jar",
       "maven": "net.fabricmc:intermediary:1.14",
       "version": "1.14",
       "stable": true
@@ -232,6 +237,7 @@ Since version 0.1.1 `launcherMeta` is now included, this can be used to get the 
     "stable": true
   },
   "intermediary": {
+    "url": "https://maven.fabricmc.net/net/fabricmc/intermediary/1.14/intermediary-1.14.jar",
     "maven": "net.fabricmc:intermediary:1.14",
     "version": "1.14",
     "stable": true

--- a/src/main/java/net/fabricmc/meta/data/VersionDatabase.java
+++ b/src/main/java/net/fabricmc/meta/data/VersionDatabase.java
@@ -49,7 +49,7 @@ public class VersionDatabase {
 		long start = System.currentTimeMillis();
 		VersionDatabase database = new VersionDatabase();
 		database.mappings = MAPPINGS_PARSER.getMeta(MavenBuildGameVersion::new, "net.fabricmc:yarn:");
-		database.intermediary = INTERMEDIARY_PARSER.getMeta(MavenVersion::new, "net.fabricmc:intermediary:");
+		database.intermediary = INTERMEDIARY_PARSER.getMeta(MavenUrlVersion::new, "net.fabricmc:intermediary:");
 		database.loader = LOADER_PARSER.getMeta(MavenBuildVersion::new, "net.fabricmc:fabric-loader:");
 		database.installer = INSTALLER_PARSER.getMeta(MavenUrlVersion::new, "net.fabricmc:fabric-installer:");
 		database.loadMcData();


### PR DESCRIPTION
Adds a `url` field to returned intermediary objects to provide requesting clients with maven data.