### PR TITLE
Add fabric-api to meta

### DIFF
--- a/src/main/java/net/fabricmc/meta/data/VersionDatabase.java
+++ b/src/main/java/net/fabricmc/meta/data/VersionDatabase.java
@@ -35,12 +35,14 @@ public class VersionDatabase {
 	public static final PomParser INTERMEDIARY_PARSER = new PomParser(MAVEN_URL + "net/fabricmc/intermediary/maven-metadata.xml");
 	public static final PomParser LOADER_PARSER = new PomParser(MAVEN_URL + "net/fabricmc/fabric-loader/maven-metadata.xml");
 	public static final PomParser INSTALLER_PARSER = new PomParser(MAVEN_URL + "net/fabricmc/fabric-installer/maven-metadata.xml");
+	public static final PomParser API_PARSER = new PomParser(MAVEN_URL + "net/fabricmc/fabric-api/fabric-api/maven-metadata.xml");
 
 	public List<BaseVersion> game;
 	public List<MavenBuildGameVersion> mappings;
 	public List<MavenVersion> intermediary;
 	public List<MavenBuildVersion> loader;
 	public List<MavenUrlVersion> installer;
+	public List<MavenBuildApiGameVersion> api;
 
 	private VersionDatabase() {
 	}
@@ -52,6 +54,7 @@ public class VersionDatabase {
 		database.intermediary = INTERMEDIARY_PARSER.getMeta(MavenVersion::new, "net.fabricmc:intermediary:");
 		database.loader = LOADER_PARSER.getMeta(MavenBuildVersion::new, "net.fabricmc:fabric-loader:");
 		database.installer = INSTALLER_PARSER.getMeta(MavenUrlVersion::new, "net.fabricmc:fabric-installer:");
+		database.api = API_PARSER.getMeta(MavenBuildApiGameVersion::new, "net.fabricmc:fabric-api:fabric-api:");
 		database.loadMcData();
 		System.out.println("DB update took " + (System.currentTimeMillis() - start) + "ms");
 		return database;

--- a/src/main/java/net/fabricmc/meta/utils/ApiVersionParser.java
+++ b/src/main/java/net/fabricmc/meta/utils/ApiVersionParser.java
@@ -1,0 +1,48 @@
+package net.fabricmc.meta.utils;
+
+public class ApiVersionParser {
+
+    private String apiVersion;
+    private String minecraftVersion;
+
+    private String version;
+    private int build;
+
+    public ApiVersionParser(String version) {
+        this.version = version;
+
+        // Fix old API versions not having MC version
+        // Recreated from curseforge version index
+        if (version.contains("0.3.1") || version.contains("0.3.0")) {
+            version = version + "-1.14";
+        }
+
+        if (version.contains("+build.")) {
+            //TODO legacy remove when no longer needed
+            this.minecraftVersion = version.substring(version.lastIndexOf('-'));
+            this.apiVersion = version.substring(0, version.lastIndexOf('+') - 1);
+            this.build = Integer.parseInt(version.substring(version.lastIndexOf("+build.")+7, version.lastIndexOf('-')));
+        } else {
+            this.minecraftVersion = version.substring(version.lastIndexOf('+'));
+            this.apiVersion = version.substring(0, version.lastIndexOf('+') - 1);
+            this.build = 999; // Build number is no longer appended to versions, use dummy version
+        }
+    }
+
+    public String getApiVersion() {
+        return apiVersion;
+    }
+
+    public String getMinecraftVersion() {
+        return minecraftVersion;
+    }
+
+    @Override
+    public String toString() {
+        return version;
+    }
+
+    public int getBuild() {
+        return build;
+    }
+}

--- a/src/main/java/net/fabricmc/meta/web/EndpointsV2.java
+++ b/src/main/java/net/fabricmc/meta/web/EndpointsV2.java
@@ -52,6 +52,9 @@ public class EndpointsV2 {
 		WebServer.jsonGet("/v2/versions/loader/:game_version", context -> withLimitSkip(context, EndpointsV2.getLoaderInfoAll(context)));
 		WebServer.jsonGet("/v2/versions/loader/:game_version/:loader_version", EndpointsV2::getLoaderInfo);
 
+		WebServer.jsonGet("/v2/versions/fabric-api", context -> withLimitSkip(context, FabricMeta.database.api));
+		WebServer.jsonGet("/v2/versions/fabric-api/:game_version", context -> withLimitSkip(context, filter(context, FabricMeta.database.api)));
+
 		WebServer.jsonGet("/v2/versions/installer", context -> withLimitSkip(context, FabricMeta.database.installer));
 
 		ProfileHandler.setup();

--- a/src/main/java/net/fabricmc/meta/web/models/MavenBuildApiGameVersion.java
+++ b/src/main/java/net/fabricmc/meta/web/models/MavenBuildApiGameVersion.java
@@ -1,0 +1,30 @@
+package net.fabricmc.meta.web.models;
+
+import net.fabricmc.meta.utils.ApiVersionParser;
+
+public class MavenBuildApiGameVersion extends MavenBuildVersion{
+
+    String gameVersion;
+
+    public MavenBuildApiGameVersion(String maven) {
+        super(maven);
+
+        String[] mavenP = maven.split(":");
+        String version = mavenP[mavenP.length-1];
+        ApiVersionParser parser = new ApiVersionParser(version);
+        gameVersion = parser.getMinecraftVersion();
+        this.build = parser.getBuild();
+        System.out.println(version);
+        this.version = version.substring(0, version.lastIndexOf(gameVersion.charAt(0)) != -1 ? version.lastIndexOf(gameVersion.charAt(0)) : version.length() - 1);
+        this.gameVersion = gameVersion.replaceAll("[+-]", ""); // Remove prefix character
+    }
+
+    public String getGameVersion() {
+        return gameVersion;
+    }
+
+    @Override
+    public boolean test(String s) {
+        return getGameVersion().equals(s);
+    }
+}

--- a/src/main/java/net/fabricmc/meta/web/models/MavenBuildVersion.java
+++ b/src/main/java/net/fabricmc/meta/web/models/MavenBuildVersion.java
@@ -23,14 +23,20 @@ public class MavenBuildVersion extends MavenVersion {
 
 	public MavenBuildVersion(String maven) {
 		super(maven);
-		String version = maven.split(":")[2];
+		String[] mavenP = maven.split(":");
+		String version = mavenP[mavenP.length-1];
 
 		if (version.contains("+build.")) {
 			separator = "+build.";
 		} else {
 			separator = ".";
 		}
-		build = Integer.parseInt(version.substring(version.lastIndexOf(".") + 1));
+		// Fix parser for oddball 20w14infinite api version (0.5.7+build.2-20w14infinite)
+		if (version.contains("+build.2-20w14infinite")) {
+			build = Integer.parseInt(version.substring(version.lastIndexOf(".") + 1, version.lastIndexOf('-')));
+		} else {
+			build = Integer.parseInt(version.substring(version.lastIndexOf(".") + 1));
+		}
 
 	}
 

--- a/src/main/java/net/fabricmc/meta/web/models/MavenVersion.java
+++ b/src/main/java/net/fabricmc/meta/web/models/MavenVersion.java
@@ -21,12 +21,17 @@ public class MavenVersion extends BaseVersion {
 	String maven;
 
 	public MavenVersion(String maven, boolean stable) {
-		super(maven.split(":")[2], stable);
+		super(getMavenParsed(maven), stable);
 		this.maven = maven;
 	}
 
 	public MavenVersion(String maven) {
 		this(maven, false);
+	}
+
+	private static String getMavenParsed(String maven) {
+		String[] mavenP = maven.split(":");
+		return mavenP[mavenP.length-1];
 	}
 
 	public String getMaven() {


### PR DESCRIPTION
Adds fabric-api to meta so that launchers such as MultiMC and potentially fabric-installer can provide an option to install fabric-api along with loader.