### PR TITLE
Add loader-style smever format MC versions

### DIFF
--- a/src/main/java/net/fabricmc/meta/data/VersionDatabase.java
+++ b/src/main/java/net/fabricmc/meta/data/VersionDatabase.java
@@ -17,6 +17,7 @@
 package net.fabricmc.meta.data;
 
 import net.fabricmc.meta.utils.MinecraftLauncherMeta;
+import net.fabricmc.meta.utils.MinecraftSemverConverter;
 import net.fabricmc.meta.utils.PomParser;
 import net.fabricmc.meta.web.models.*;
 
@@ -86,7 +87,7 @@ public class VersionDatabase {
 			return 0;
 		});
 
-		game = minecraftVersions.stream().map(s -> new BaseVersion(s, launcherMeta.isStable(s))).collect(Collectors.toList());
+		game = minecraftVersions.stream().map(s -> new BaseVersion(s, launcherMeta.isStable(s), MinecraftSemverConverter.convert(launcherMeta.majorVersion(s), s))).collect(Collectors.toList());
 	}
 
 }

--- a/src/main/java/net/fabricmc/meta/utils/MinecraftLauncherMeta.java
+++ b/src/main/java/net/fabricmc/meta/utils/MinecraftLauncherMeta.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Optional;
 
 public class MinecraftLauncherMeta {
 
@@ -42,6 +43,15 @@ public class MinecraftLauncherMeta {
 
 	public boolean isStable(String id) {
 		return versions.stream().anyMatch(version -> version.id.equals(id) && version.type.equals("release"));
+	}
+
+	public String majorVersion(String id) {
+		Optional<Version> vers = versions.stream().filter(version -> version.id.equals(id)).findFirst();
+		if (vers.isPresent()) {
+			return vers.get().getMajorVersion();
+		} else {
+			return "";
+		}
 	}
 
 	public int getIndex(String version){
@@ -79,6 +89,25 @@ public class MinecraftLauncherMeta {
 
 		public String getReleaseTime() {
 			return releaseTime;
+		}
+
+		public String getMajorVersion() {
+			String json = null;
+			try {
+				json = IOUtils.toString(new URL(url), StandardCharsets.UTF_8);
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+			return GSON.fromJson(json, Meta.class).getAssets();
+		}
+	}
+
+	public static class Meta {
+
+		String assets;
+
+		public String getAssets() {
+			return assets;
 		}
 	}
 

--- a/src/main/java/net/fabricmc/meta/utils/MinecraftSemverConverter.java
+++ b/src/main/java/net/fabricmc/meta/utils/MinecraftSemverConverter.java
@@ -1,0 +1,130 @@
+package net.fabricmc.meta.utils;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class MinecraftSemverConverter {
+    // From Fabric Loader
+    private static final Pattern RELEASE_PATTERN = Pattern.compile("\\d+\\.\\d+(\\.\\d+)?");
+    private static final Pattern PRE_RELEASE_PATTERN = Pattern.compile(".+(?:-pre| Pre-[Rr]elease )(\\d+)");
+    private static final Pattern RELEASE_CANDIDATE_PATTERN = Pattern.compile(".+(?:-rc| [Rr]elease Candidate )(\\d+)");
+    private static final Pattern SNAPSHOT_PATTERN = Pattern.compile("(?:Snapshot )?(\\d+)w0?(0|[1-9]\\d*)([a-z])");
+
+    private static final Pattern RELEASE_PATTERN_START = Pattern.compile("\\d+\\.\\d+\\.(\\d+)");
+
+
+    private MinecraftSemverConverter() {}
+
+    // Adapted from Fabric Loader
+    public static String convert(String majorVersion, String name) {
+        // This does not match loader's output as the needed data is not available
+        if (name.contains("combat")) {
+            return normalizeVersion(name);
+        }
+
+        Matcher matcher;
+
+        matcher = RELEASE_PATTERN.matcher(name);
+        if (matcher.matches()) {return name;}
+
+        if (name.startsWith(majorVersion)) {
+            Matcher m = RELEASE_PATTERN_START.matcher(name);
+            matcher = RELEASE_CANDIDATE_PATTERN.matcher(name);
+            if (matcher.matches()) {
+                String rcBuild = matcher.group(1);
+
+                // This is a hack to fake 1.16's new release candidates to follow on from the 8 pre releases.
+                if (name.split("-")[0].equals("1.16")) {
+                    int build = Integer.parseInt(rcBuild);
+                    rcBuild = Integer.toString(8 + build);
+                }
+
+                name = String.format("rc.%s", rcBuild);
+            } else {
+                matcher = PRE_RELEASE_PATTERN.matcher(name);
+
+                if (matcher.matches()) {
+                    boolean legacyVersion;
+
+                    // Handle lack of semver parser
+                    int minor = 0;
+                    if (m.find()) {
+                        minor = Integer.parseInt(m.group(1));
+                    }
+
+                    legacyVersion = Integer.parseInt(majorVersion.split("\\.")[1]) < 16 ||
+                            (Integer.parseInt(majorVersion.split("\\.")[1]) == 16 && minor < 1);
+
+                    // Mark pre-releases as 'beta' versions, except for version 1.16 and before, where they are 'rc'
+                    if (legacyVersion) {
+                        name = String.format("rc.%s", matcher.group(1));
+                    } else {
+                        name = String.format("beta.%s", matcher.group(1));
+                    }
+                }
+            }
+            if (m.reset().find()) {
+                return String.format("%s-%s", m.group(), name);
+            }
+        } else if ((matcher = SNAPSHOT_PATTERN.matcher(name)).matches()) {
+            name = String.format("alpha.%s.%s.%s", matcher.group(1), matcher.group(2), matcher.group(3));
+        } else {
+            name = normalizeVersion(name);
+        }
+
+        return String.format("%s-%s", majorVersion.replace("-af", ""), name);
+    }
+
+    // Adapted from Fabric loader
+    private static String normalizeVersion(String version) {
+        StringBuilder ret = new StringBuilder(version.length() + 5);
+        boolean lastIsDigit = false;
+        boolean lastIsLeadingZero = false;
+        boolean lastIsSeparator = false;
+
+        for (int i = 0, max = version.length(); i < max; i++) {
+            char c = version.charAt(i);
+
+            if (c >= '0' && c <= '9') {
+                if (i > 0 && !lastIsDigit && !lastIsSeparator) { // no separator between non-number and number, add one
+                    ret.append('.');
+                } else if (lastIsDigit && lastIsLeadingZero) { // leading zero in output -> strip
+                    ret.setLength(ret.length() - 1);
+                }
+
+                lastIsLeadingZero = c == '0' && (!lastIsDigit || lastIsLeadingZero); // leading or continued leading zero(es)
+                lastIsSeparator = false;
+                lastIsDigit = true;
+            } else if (c == '.' || c == '-') { // keep . and - separators
+                if (lastIsSeparator) continue;
+
+                lastIsSeparator = true;
+                lastIsDigit = false;
+            } else if ((c < 'A' || c > 'Z') && (c < 'a' || c > 'z')) { // replace remaining non-alphanumeric with .
+                if (lastIsSeparator) continue;
+
+                c = '.';
+                lastIsSeparator = true;
+                lastIsDigit = false;
+            } else { // keep other characters (alpha)
+                if (lastIsDigit) ret.append('.'); // no separator between number and non-number, add one
+
+                lastIsSeparator = false;
+                lastIsDigit = false;
+            }
+
+            ret.append(c);
+        }
+
+        // strip leading and trailing .
+
+        int start = 0;
+        while (start < ret.length() && ret.charAt(start) == '.') start++;
+
+        int end = ret.length();
+        while (end > start && ret.charAt(end - 1) == '.') end--;
+
+        return ret.substring(start, end);
+    }
+
+}

--- a/src/main/java/net/fabricmc/meta/web/EndpointsV2.java
+++ b/src/main/java/net/fabricmc/meta/web/EndpointsV2.java
@@ -39,6 +39,7 @@ public class EndpointsV2 {
 		WebServer.jsonGet("/v2/versions", () -> FabricMeta.database);
 
 		WebServer.jsonGet("/v2/versions/game", () -> FabricMeta.database.game);
+		WebServer.jsonGet("/v2/versions/game/:game_version", context -> withLimitSkip(context, filter(context, FabricMeta.database.game)));
 		WebServer.jsonGet("/v2/versions/game/yarn", () -> compatibleGameVersions(FabricMeta.database.mappings, MavenBuildGameVersion::getGameVersion, v -> new BaseVersion(v.getGameVersion(), v.isStable())));
 		WebServer.jsonGet("/v2/versions/game/intermediary", () -> compatibleGameVersions(FabricMeta.database.intermediary, BaseVersion::getVersion, v -> new BaseVersion(v.getVersion(), v.isStable())));
 

--- a/src/main/java/net/fabricmc/meta/web/models/BaseVersion.java
+++ b/src/main/java/net/fabricmc/meta/web/models/BaseVersion.java
@@ -22,10 +22,17 @@ public class BaseVersion implements Predicate<String> {
 
 	String version;
 	boolean stable = false;
+	String semver;
 
 	public BaseVersion(String version, boolean stable) {
 		this.version = version;
 		this.stable = stable;
+	}
+
+	public BaseVersion(String version, boolean stable, String semver) {
+		this.version = version;
+		this.stable = stable;
+		this.semver = semver;
 	}
 
 	public String getVersion() {
@@ -38,6 +45,10 @@ public class BaseVersion implements Predicate<String> {
 
 	public void setStable(boolean stable) {
 		this.stable = stable;
+	}
+
+	public String getSemver() {
+		return semver;
 	}
 
 	@Override


### PR DESCRIPTION
Add a `semver` entry to `v2/versions/game` and create a `v2/versions/game/:game_version` endpoint.

Allows external tools to convert an MC version* to something semver compliant for parsing. 

Useful for tools such as `modmuss.me/fabric.html` to include an entry for use in `fabric.mod.json` as it is not always immediately obvious how loader will translate the version for enforcement.

* Combat snapshots no included.