### PR TITLE
Add recommended versions endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,31 @@ Downloads a zip file with the launcher's profile json, and the dummy jar. To be 
 
 Returns the JSON file in format of the launcher JSON, but with the server's main class.
 
+### /v2/versions/:game_version
+
+Returns the best versions of yarn and loader to use for the supplied game version - this is a way to programmatically obtain the data at the [versions page](https://fabricmc.net/versions.html)
+
+```json
+{
+  "gameVersion": "1.17.1",
+  "yarn": {
+    "gameVersion": "1.17.1",
+    "separator": "+build.",
+    "build": 63,
+    "maven": "net.fabricmc:yarn:1.17.1+build.63",
+    "version": "1.17.1+build.63",
+    "stable": false
+  },
+  "loader": {
+    "separator": ".",
+    "build": 5,
+    "maven": "net.fabricmc:fabric-loader:0.12.5",
+    "version": "0.12.5",
+    "stable": true
+  }
+}
+```
+
 # V1
 
 ### /v1/versions

--- a/src/main/java/net/fabricmc/meta/web/EndpointsV2.java
+++ b/src/main/java/net/fabricmc/meta/web/EndpointsV2.java
@@ -34,145 +34,170 @@ import java.util.stream.Stream;
 @SuppressWarnings("Duplicates")
 public class EndpointsV2 {
 
-	public static void setup() {
+    public static void setup() {
 
-		WebServer.jsonGet("/v2/versions", () -> FabricMeta.database);
+        WebServer.jsonGet("/v2/versions", () -> FabricMeta.database);
 
-		WebServer.jsonGet("/v2/versions/game", () -> FabricMeta.database.game);
-		WebServer.jsonGet("/v2/versions/game/yarn", () -> compatibleGameVersions(FabricMeta.database.mappings, MavenBuildGameVersion::getGameVersion, v -> new BaseVersion(v.getGameVersion(), v.isStable())));
-		WebServer.jsonGet("/v2/versions/game/intermediary", () -> compatibleGameVersions(FabricMeta.database.intermediary, BaseVersion::getVersion, v -> new BaseVersion(v.getVersion(), v.isStable())));
+        WebServer.jsonGet("/v2/versions/game", () -> FabricMeta.database.game);
+        WebServer.jsonGet("/v2/versions/game/yarn", () -> compatibleGameVersions(FabricMeta.database.mappings, MavenBuildGameVersion::getGameVersion, v -> new BaseVersion(v.getGameVersion(), v.isStable())));
+        WebServer.jsonGet("/v2/versions/game/intermediary", () -> compatibleGameVersions(FabricMeta.database.intermediary, BaseVersion::getVersion, v -> new BaseVersion(v.getVersion(), v.isStable())));
 
-		WebServer.jsonGet("/v2/versions/yarn", context -> withLimitSkip(context, FabricMeta.database.mappings));
-		WebServer.jsonGet("/v2/versions/yarn/:game_version", context -> withLimitSkip(context, filter(context, FabricMeta.database.mappings)));
+        WebServer.jsonGet("/v2/versions/yarn", context -> withLimitSkip(context, FabricMeta.database.mappings));
+        WebServer.jsonGet("/v2/versions/yarn/:game_version", context -> withLimitSkip(context, filter(context, FabricMeta.database.mappings)));
 
-		WebServer.jsonGet("/v2/versions/intermediary", () -> FabricMeta.database.intermediary);
-		WebServer.jsonGet("/v2/versions/intermediary/:game_version", context -> filter(context, FabricMeta.database.intermediary));
+        WebServer.jsonGet("/v2/versions/intermediary", () -> FabricMeta.database.intermediary);
+        WebServer.jsonGet("/v2/versions/intermediary/:game_version", context -> filter(context, FabricMeta.database.intermediary));
 
-		WebServer.jsonGet("/v2/versions/loader", context -> withLimitSkip(context, FabricMeta.database.getLoader()));
-		WebServer.jsonGet("/v2/versions/loader/:game_version", context -> withLimitSkip(context, EndpointsV2.getLoaderInfoAll(context)));
-		WebServer.jsonGet("/v2/versions/loader/:game_version/:loader_version", EndpointsV2::getLoaderInfo);
+        WebServer.jsonGet("/v2/versions/loader", context -> withLimitSkip(context, FabricMeta.database.getLoader()));
+        WebServer.jsonGet("/v2/versions/loader/:game_version", context -> withLimitSkip(context, EndpointsV2.getLoaderInfoAll(context)));
+        WebServer.jsonGet("/v2/versions/loader/:game_version/:loader_version", EndpointsV2::getLoaderInfo);
 
-		WebServer.jsonGet("/v2/versions/installer", context -> withLimitSkip(context, FabricMeta.database.installer));
+        WebServer.jsonGet("/v2/versions/installer", context -> withLimitSkip(context, FabricMeta.database.installer));
 
-		ProfileHandler.setup();
-	}
+        WebServer.jsonGet("/v2/versions/:game_version", context -> EndpointsV2.getRecommendedVersions(context));
 
-	private static <T> List<T> withLimitSkip(Context context, List<T> list) {
-		if(list == null){
-			return Collections.emptyList();
-		}
-		int limit = context.queryParam("limit", Integer.class, "0").check(i -> i >= 0).get();
-		int skip = context.queryParam("skip", Integer.class, "0").check(i -> i >= 0).get();
+        ProfileHandler.setup();
+    }
 
-		Stream<T> listStream = list.stream().skip(skip);
+    private static <T> List<T> withLimitSkip(Context context, List<T> list) {
+        if (list == null) {
+            return Collections.emptyList();
+        }
+        int limit = context.queryParam("limit", Integer.class, "0").check(i -> i >= 0).get();
+        int skip = context.queryParam("skip", Integer.class, "0").check(i -> i >= 0).get();
 
-		if (limit > 0) {
-			listStream = listStream.limit(limit);
-		}
+        Stream<T> listStream = list.stream().skip(skip);
 
-		return listStream.collect(Collectors.toList());
-	}
+        if (limit > 0) {
+            listStream = listStream.limit(limit);
+        }
 
-	private static <T extends Predicate<String>> List<T> filter(Context context, List<T> versionList) {
-		if (!context.pathParamMap().containsKey("game_version")) {
-			return Collections.emptyList();
-		}
-		return versionList.stream().filter(t -> t.test(context.pathParam("game_version"))).collect(Collectors.toList());
+        return listStream.collect(Collectors.toList());
+    }
 
-	}
+    private static <T extends Predicate<String>> List<T> filter(Context context, List<T> versionList) {
+        if (!context.pathParamMap().containsKey("game_version")) {
+            return Collections.emptyList();
+        }
+        return versionList.stream().filter(t -> t.test(context.pathParam("game_version"))).collect(Collectors.toList());
 
-	private static Object getLoaderInfo(Context context) {
-		if (!context.pathParamMap().containsKey("game_version")) {
+    }
+
+    private static Object getLoaderInfo(Context context) {
+        if (!context.pathParamMap().containsKey("game_version")) {
+            return null;
+        }
+        if (!context.pathParamMap().containsKey("loader_version")) {
+            return null;
+        }
+
+        String gameVersion = context.pathParam("game_version");
+        String loaderVersion = context.pathParam("loader_version");
+
+        MavenBuildVersion loader = FabricMeta.database.getAllLoader().stream()
+                .filter(mavenBuildVersion -> loaderVersion.equals(mavenBuildVersion.getVersion()))
+                .findFirst().orElse(null);
+
+        MavenVersion mappings = FabricMeta.database.intermediary.stream()
+                .filter(t -> t.test(gameVersion))
+                .findFirst().orElse(null);
+
+        if (loader == null) {
+            context.status(400);
+            return "no loader version found for " + gameVersion;
+        }
+        if (mappings == null) {
+            context.status(400);
+            return "no mappings version found for " + gameVersion;
+        }
+        return new LoaderInfoV2(loader, mappings).populateMeta();
+    }
+
+    private static List<?> getLoaderInfoAll(Context context) {
+        if (!context.pathParamMap().containsKey("game_version")) {
+            return null;
+        }
+        String gameVersion = context.pathParam("game_version");
+
+        MavenVersion mappings = FabricMeta.database.intermediary.stream()
+                .filter(t -> t.test(gameVersion))
+                .findFirst().orElse(null);
+
+        if (mappings == null) {
+            return Collections.emptyList();
+        }
+
+        List<LoaderInfoV2> infoList = new ArrayList<>();
+
+        for (MavenBuildVersion loader : FabricMeta.database.getLoader()) {
+            infoList.add(new LoaderInfoV2(loader, mappings).populateMeta());
+        }
+        return infoList;
+    }
+
+    private static Object getRecommendedVersions(Context context) {
+        if (!context.pathParamMap().containsKey("game_version")) {
+            return null;
+        }
+        String gameVersion = context.pathParam("game_version");
+
+        List<MavenBuildGameVersion> yarn = FabricMeta.database.mappings.stream()
+                .filter(t -> t.test(gameVersion))
+                .collect(Collectors.toList());
+
+		List<MavenBuildVersion> loader = FabricMeta.database.getLoader();
+
+		if (yarn.isEmpty()) {
 			return null;
 		}
-		if (!context.pathParamMap().containsKey("loader_version")) {
+
+		if (loader.isEmpty()) {
 			return null;
 		}
 
-		String gameVersion = context.pathParam("game_version");
-		String loaderVersion = context.pathParam("loader_version");
+        return new RecommendedVersions(gameVersion, yarn.get(0), loader.get(0));
+    }
 
-		MavenBuildVersion loader = FabricMeta.database.getAllLoader().stream()
-			.filter(mavenBuildVersion -> loaderVersion.equals(mavenBuildVersion.getVersion()))
-			.findFirst().orElse(null);
+    private static <T extends BaseVersion> List<BaseVersion> compatibleGameVersions(List<T> list, Function<T, String> gameVersionSupplier, Function<T, BaseVersion> baseVersionSupplier) {
+        List<BaseVersion> versions = new ArrayList<>();
+        Predicate<String> contains = s -> versions.stream().anyMatch(baseVersion -> baseVersion.getVersion().equals(s));
 
-		MavenVersion mappings = FabricMeta.database.intermediary.stream()
-			.filter(t -> t.test(gameVersion))
-			.findFirst().orElse(null);
+        for (T entry : list) {
+            if (!contains.test(gameVersionSupplier.apply(entry))) {
+                versions.add(baseVersionSupplier.apply(entry));
+            }
+        }
 
-		if (loader == null) {
-			context.status(400);
-			return "no loader version found for " + gameVersion;
-		}
-		if (mappings == null) {
-			context.status(400);
-			return "no mappings version found for " + gameVersion;
-		}
-		return new LoaderInfoV2(loader, mappings).populateMeta();
-	}
+        return versions;
+    }
 
-	private static List<?> getLoaderInfoAll(Context context) {
-		if (!context.pathParamMap().containsKey("game_version")) {
-			return null;
-		}
-		String gameVersion = context.pathParam("game_version");
+    public static void fileDownload(String path, String ext, Function<LoaderInfoV2, String> fileNameFunction, Function<LoaderInfoV2, CompletableFuture<InputStream>> streamSupplier) {
+        WebServer.javalin.get("/v2/versions/loader/:game_version/:loader_version/" + path + "/" + ext, ctx -> {
+            Object obj = getLoaderInfo(ctx);
 
-		MavenVersion mappings = FabricMeta.database.intermediary.stream()
-			.filter(t -> t.test(gameVersion))
-			.findFirst().orElse(null);
+            if (obj instanceof String) {
+                ctx.result((String) obj);
+            } else if (obj instanceof LoaderInfoV2) {
+                LoaderInfoV2 versionInfo = (LoaderInfoV2) obj;
 
-		if(mappings == null){
-			return Collections.emptyList();
-		}
+                CompletableFuture<InputStream> streamFuture = streamSupplier.apply(versionInfo);
 
-		List<LoaderInfoV2> infoList = new ArrayList<>();
+                if (ext.equals("zip")) {
+                    //Set the filename to download
+                    ctx.header(Header.CONTENT_DISPOSITION, String.format("attachment; filename=\"%s\"", fileNameFunction.apply(versionInfo)));
 
-		for(MavenBuildVersion loader : FabricMeta.database.getLoader()){
-			infoList.add(new LoaderInfoV2(loader, mappings).populateMeta());
-		}
-		return infoList;
-	}
+                    ctx.contentType("application/zip");
+                } else {
+                    ctx.contentType("application/json");
+                }
 
-	private static <T extends BaseVersion> List<BaseVersion> compatibleGameVersions(List<T> list, Function<T, String> gameVersionSupplier, Function<T, BaseVersion> baseVersionSupplier){
-		List<BaseVersion> versions = new ArrayList<>();
-		Predicate<String> contains = s -> versions.stream().anyMatch(baseVersion -> baseVersion.getVersion().equals(s));
+                //Cache for a day
+                ctx.header(Header.CACHE_CONTROL, "public, max-age=86400");
 
-		for(T entry : list){
-			if (!contains.test(gameVersionSupplier.apply(entry))){
-				versions.add(baseVersionSupplier.apply(entry));
-			}
-		}
-
-		return versions;
-	}
-
-	public static void fileDownload(String path, String ext, Function<LoaderInfoV2, String> fileNameFunction, Function<LoaderInfoV2, CompletableFuture<InputStream>> streamSupplier) {
-		WebServer.javalin.get("/v2/versions/loader/:game_version/:loader_version/" + path + "/" + ext, ctx -> {
-			Object obj = getLoaderInfo(ctx);
-
-			if (obj instanceof String) {
-				ctx.result((String) obj);
-			} else if (obj instanceof LoaderInfoV2) {
-				LoaderInfoV2 versionInfo = (LoaderInfoV2) obj;
-
-				CompletableFuture<InputStream> streamFuture = streamSupplier.apply(versionInfo);
-
-				if (ext.equals("zip")) {
-					//Set the filename to download
-					ctx.header(Header.CONTENT_DISPOSITION, String.format("attachment; filename=\"%s\"", fileNameFunction.apply(versionInfo)));
-
-					ctx.contentType("application/zip");
-				} else {
-					ctx.contentType("application/json");
-				}
-
-				//Cache for a day
-				ctx.header(Header.CACHE_CONTROL, "public, max-age=86400");
-
-				ctx.result(streamFuture);
-			} else {
-				ctx.result("An internal error occurred");
-			}
-		});
-	}
+                ctx.result(streamFuture);
+            } else {
+                ctx.result("An internal error occurred");
+            }
+        });
+    }
 }

--- a/src/main/java/net/fabricmc/meta/web/models/RecommendedVersions.java
+++ b/src/main/java/net/fabricmc/meta/web/models/RecommendedVersions.java
@@ -1,0 +1,29 @@
+package net.fabricmc.meta.web.models;
+
+/**
+ * @author Jamalam360
+ */
+public class RecommendedVersions {
+    String gameVersion;
+    MavenBuildGameVersion yarn;
+    MavenBuildVersion loader;
+    //FAPI is yet to be added since it isn't available via this API yet. Users could use the CurseForge API meanwhile
+
+    public RecommendedVersions(String gameVersion, MavenBuildGameVersion yarn, MavenBuildVersion loader) {
+        this.gameVersion = gameVersion;
+        this.yarn = yarn;
+        this.loader = loader;
+    }
+
+    public String getGameVersion() {
+        return gameVersion;
+    }
+
+    public MavenBuildGameVersion getYarnVersion() {
+        return yarn;
+    }
+
+    public MavenBuildVersion getLoaderVersion() {
+        return loader;
+    }
+}


### PR DESCRIPTION
This PR adds an endpoint to fetch the data that is normally available at `https://fabricmc.net/versions.html` through the API. It is marked as a draft as it needs some discussion - I'll self review it to add some comments on things that need addressing. It would be ideal if #10 was merged so that it could also provide FAPI?