### PR TITLE
change VersionDatabase to not spam console with "Removing ..." messages

### DIFF
--- a/src/main/java/net/fabricmc/meta/data/VersionDatabase.java
+++ b/src/main/java/net/fabricmc/meta/data/VersionDatabase.java
@@ -87,7 +87,7 @@ public class VersionDatabase {
 			if (launcherMeta.getVersions().stream().noneMatch(version -> version.getId().equals(o.getVersion()))) {
 				// only print unmatched versions once so that it doesn't spam the console with "Removing ..." messages
 				if (incorrectVersions.stream().noneMatch(o.getVersion()::equals)) {
-					LOGGER.warn("Removing " + o.getVersion() + " as it doesn't have a valid intermediary match");
+					LOGGER.warn("Removing " + o.getVersion() + " as it doesn't match a valid mc version");
 					incorrectVersions.add(o.getVersion());
 				}
 				return true;

--- a/src/main/java/net/fabricmc/meta/data/VersionDatabase.java
+++ b/src/main/java/net/fabricmc/meta/data/VersionDatabase.java
@@ -20,7 +20,7 @@ import net.fabricmc.meta.utils.MinecraftLauncherMeta;
 import net.fabricmc.meta.utils.PomParser;
 import net.fabricmc.meta.web.models.*;
 import org.slf4j.Logger;
-import org.slf4j.impl.SimpleLoggerFactory;
+import org.slf4j.LoggerFactory;
 
 import javax.xml.stream.XMLStreamException;
 import java.io.IOException;
@@ -39,15 +39,14 @@ public class VersionDatabase {
 	public static final PomParser LOADER_PARSER = new PomParser(MAVEN_URL + "net/fabricmc/fabric-loader/maven-metadata.xml");
 	public static final PomParser INSTALLER_PARSER = new PomParser(MAVEN_URL + "net/fabricmc/fabric-installer/maven-metadata.xml");
 
+	private static final ArrayList<String> incorrectVersions = new ArrayList<>();
+	private static final Logger LOGGER = LoggerFactory.getLogger(VersionDatabase.class);
+
 	public List<BaseVersion> game;
 	public List<MavenBuildGameVersion> mappings;
 	public List<MavenVersion> intermediary;
 	private List<MavenBuildVersion> loader;
 	public List<MavenUrlVersion> installer;
-
-	private static final ArrayList<String> incorrectVersions = new ArrayList<>();
-
-	private static final Logger LOGGER = new SimpleLoggerFactory().getLogger(VersionDatabase.class.getName());
 
 	private VersionDatabase() {
 	}
@@ -67,7 +66,7 @@ public class VersionDatabase {
 		});
 		database.installer = INSTALLER_PARSER.getMeta(MavenUrlVersion::new, "net.fabricmc:fabric-installer:");
 		database.loadMcData();
-		LOGGER.info("DB update took " + (System.currentTimeMillis() - start) + "ms");
+		LOGGER.info("DB update took {} ms", (System.currentTimeMillis() - start));
 		return database;
 	}
 
@@ -87,7 +86,7 @@ public class VersionDatabase {
 			if (launcherMeta.getVersions().stream().noneMatch(version -> version.getId().equals(o.getVersion()))) {
 				// only print unmatched versions once so that it doesn't spam the console with "Removing ..." messages
 				if (incorrectVersions.stream().noneMatch(o.getVersion()::equals)) {
-					LOGGER.warn("Removing " + o.getVersion() + " as it doesn't match a valid mc version");
+					LOGGER.warn("Removing {} as it doesn't match a valid mc version", o.getVersion());
 					incorrectVersions.add(o.getVersion());
 				}
 				return true;


### PR DESCRIPTION
This pr makes it so that each version that lacks matching intermediaries only gets output once to the console, reducing spam from the "Removing xxx" messages. It also changes both the removing and db update messages to use slf4j to make the log look consistent because javalin already defaults to using slf4j for its output.