### PR TITLE
Fix launching the game REQUEST_FAILED

### DIFF
--- a/src/main/java/net/fabricmc/meta/web/ProfileHandler.java
+++ b/src/main/java/net/fabricmc/meta/web/ProfileHandler.java
@@ -60,7 +60,7 @@ public class ProfileHandler {
 		if (env.game().version().obfuscated()) {
 			return String.format("fabric-loader-%s-%s", loaderVersion, env.game().intermediary().getVersion());
 		} else {
-			return String.format("fabric-loader-%s", loaderVersion);
+			return String.format("fabric-loader-%s-%s", loaderVersion, env.game().version().id());
 		}
 	}
 


### PR DESCRIPTION
<img width="606" height="413" alt="{8BBE905E-F8AC-4999-91F2-C4AF3CE01A3D}" src="https://github.com/user-attachments/assets/51d83303-4c22-43bf-875a-7710b1cd282b" />

When downloading the unobfuscated version, an incorrect id in the JSON file can cause the download to fail.
https://meta.fabricmc.net/v2/versions/loader/1.21.11-pre3_unobfuscated/0.18.1/profile/json